### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ whats.send_message("5511942424242", "Message goes here.")
 }
 ```
 
+### Send HSM (templated) messages
+Send a kind of message that will not allow the receiver to flag it as spam since it's template was pre approved by WhatsApp, find more informations [here](https://developers.facebook.com/docs/whatsapp/message-templates)
+
+```ruby
+whats.send_hsm_message(
+  "+1234567890",
+  "cdb2df51_9816_c754_c5a4_64cdabdcad3e",
+  "purchase_with_credit_card",
+  [ # ordered list of replacements that will happen at the template
+    {default: "$10"},
+    {default: "300"},
+  ]
+)
+```
+
 ## Tests
 
 ### Running tests

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ whats.send_hsm_message(
     {default: "300"},
   ]
 )
+
+# output:
+
+{
+  "messages": [{
+    "id": "gBEGkYiEB1VXAglK1ZEqA1YKPrU"
+  }]
+}
 ```
 
 ## Tests


### PR DESCRIPTION
There is a public method available in the whats api that was not documented in the readme file, as is all the others.

This PR means to fix that, adding the missing documentation.

**CHANGELOG** :memo:

* Add documentation for the `send_hsm_message` method on whats api
